### PR TITLE
Azure Web Appのリソース名をシークレットに移す

### DIFF
--- a/.github/workflows/aspnetcore.yml
+++ b/.github/workflows/aspnetcore.yml
@@ -11,7 +11,6 @@ env:
   DOTNET_VERSION: '6.0.x'
   SOURCE_CODE_PATH: 'razorpageapp/razorpageapp.csproj'
   BUILD_CONFIGURATION: Release
-  AZURE_WEBAPP_NAME: 'app-yuta-github-actions-samples'
 
 jobs:
   build:
@@ -61,7 +60,7 @@ jobs:
         id: deploy-to-webapp
         uses: azure/webapps-deploy@v2
         with: 
-          app-name: ${{ env.AZURE_WEBAPP_NAME }}
+          app-name: ${{ secrets.AZURE_WEBAPP_NAME }}
           slot-name: 'Production'
           publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
           package: .

--- a/.github/workflows/azure-app-service-settings.yml
+++ b/.github/workflows/azure-app-service-settings.yml
@@ -3,9 +3,6 @@ name: Azure App Service Settings
 on:
   workflow_dispatch:
   
-env:
-  AZURE_WEBAPP_NAME: 'app-yuta-github-actions-samples'
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -18,6 +15,6 @@ jobs:
       - name: Azure App Service Settings
         uses: Azure/appservice-settings@v1
         with:
-          app-name: ${{env.AZURE_WEBAPP_NAME}}
+          app-name: ${{secrets.AZURE_WEBAPP_NAME}}
           slot-name: 'Production'
           app-settings-json: '${{secrets.AZURE_WEBAPP_APP_SETTINGS}}'

--- a/.github/workflows/node-express.yml
+++ b/.github/workflows/node-express.yml
@@ -8,8 +8,6 @@ on:
   workflow_dispatch:
 
 env:
-  AZURE_WEBAPP_NAME: 'app-yuta-github-actions-samples'
-  AZURE_WEBAPP_PACKAGE_PATH: '.'
   NODE_VERSION: '16.x'
   WORKING_DIRECTORY: nodejs/express
 
@@ -60,6 +58,6 @@ jobs:
         id: deploy-to-webapp 
         uses: azure/webapps-deploy@v2
         with:
-          app-name: ${{ env.AZURE_WEBAPP_NAME }}
+          app-name: ${{ secrets.AZURE_WEBAPP_NAME }}
           publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
           slot-name: 'Production'

--- a/.github/workflows/python-django.yml
+++ b/.github/workflows/python-django.yml
@@ -10,7 +10,6 @@ on:
 env:
   PYTHON_VERSION: '3.7'
   WORKING_DIRECTORY: python/django
-  AZURE_WEBAPP_NAME: 'app-yuta-github-actions-samples'
 
 jobs:
   build:
@@ -62,6 +61,6 @@ jobs:
         uses: azure/webapps-deploy@v2
         id: deploy-to-webapp
         with:
-          app-name: ${{ env.AZURE_WEBAPP_NAME }}
+          app-name: ${{ secrets.AZURE_WEBAPP_NAME }}
           slot-name: 'Production'
           publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}

--- a/.github/workflows/python-fastapi.yml
+++ b/.github/workflows/python-fastapi.yml
@@ -10,7 +10,6 @@ on:
 env:
   PYTHON_VERSION: '3.7'
   WORKING_DIRECTORY: python/fastapi
-  AZURE_WEBAPP_NAME: 'app-yuta-github-actions-samples'
 
 jobs:
   build:
@@ -62,6 +61,6 @@ jobs:
         uses: azure/webapps-deploy@v2
         id: deploy-to-webapp
         with:
-          app-name: ${{ env.AZURE_WEBAPP_NAME }}
+          app-name: ${{ secrets.AZURE_WEBAPP_NAME }}
           slot-name: 'Production'
           publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}


### PR DESCRIPTION
リソースが変わった際の手間を減らすため