### PR TITLE
Create net80-eshop.yml

### DIFF
--- a/.github/workflows/net80-eshop.yml
+++ b/.github/workflows/net80-eshop.yml
@@ -1,0 +1,31 @@
+# https://github.com/dotnet/eshop
+name: Build eshop
+
+on:
+  workflow_dispatch:
+    inputs:
+      checkout-version:
+        description: actions/checkout version
+        required: true
+        type: choice
+        options:
+          - v3
+          - v4
+
+env:
+  REPOSITORY_URL: https://github.com/dotnet/eshop
+
+jobs:
+  build-eshop:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: ${{ env.REPOSITORY_URL }}
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '8.0.x'
+      - name: Build
+        run: |
+          dotnet build --project src/eShop.AppHost/eShop.AppHost.csproj


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for building the `eshop` project from the `dotnet` repository. The workflow is defined in the `.github/workflows/net80-eshop.yml` file. It is triggered manually (`workflow_dispatch`) and requires an input to specify the version of `actions/checkout` to use. The workflow runs on an `ubuntu-latest` environment and includes steps for checking out the `eshop` repository, setting up .NET, and building the `eshop` project.